### PR TITLE
Лимит для Кило

### DIFF
--- a/Resources/Prototypes/_Stories/Maps/kilo.yml
+++ b/Resources/Prototypes/_Stories/Maps/kilo.yml
@@ -3,6 +3,7 @@
   mapName: '[КТ] Kilo Station'
   mapPath: /Maps/_Stories/kilo.yml
   minPlayers: 35
+  maxPlayers: 70
   stations:
     Kilo:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Повысил максимальный лимит игроков для Кило до 70

## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Маловато спавнов ролей для того чтобы выдавать карту на высокий онлайн