### PR TITLE
Rebalance visions

### DIFF
--- a/Content.Client/_Stories/ThermalVision/ThermalVisionSystem.cs
+++ b/Content.Client/_Stories/ThermalVision/ThermalVisionSystem.cs
@@ -26,7 +26,7 @@ public sealed class ThermalVisionSystem : SharedThermalVisionSystem
 
     private void OnThermalVisionDetached(Entity<ThermalVisionComponent> ent, ref LocalPlayerDetachedEvent args)
     {
-        Off();
+        Off(ent.Comp.Innate);
     }
 
     protected override void ThermalVisionChanged(Entity<ThermalVisionComponent> ent)
@@ -35,8 +35,9 @@ public sealed class ThermalVisionSystem : SharedThermalVisionSystem
             return;
 
         if (ent.Comp.Enabled)
-            On();
-        else Off();
+            On(ent.Comp.Innate);
+        else
+            Off(ent.Comp.Innate);
     }
 
     protected override void ThermalVisionRemoved(Entity<ThermalVisionComponent> ent)
@@ -44,20 +45,28 @@ public sealed class ThermalVisionSystem : SharedThermalVisionSystem
         if (ent != _player.LocalEntity)
             return;
 
-        Off();
+        Off(ent.Comp.Innate);
     }
 
-    private void Off()
+    private void Off(bool isInnate)
     {
         _overlay.RemoveOverlay(new ThermalVisionOverlay());
-        _light.DrawShadows = true;
-        _light.DrawLighting = true;
+
+        if(isInnate)
+        {
+            _light.DrawShadows = true;
+            _light.DrawLighting = true;
+        }
     }
 
-    private void On()
+    private void On(bool isInnate)
     {
         _overlay.AddOverlay(new ThermalVisionOverlay());
-        _light.DrawShadows = false;
-        _light.DrawLighting = false;
+
+        if(isInnate)
+        {
+            _light.DrawShadows = false;
+            _light.DrawLighting = false;
+        }
     }
 }

--- a/Resources/Prototypes/_Stories/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Stories/Catalog/uplink_catalog.yml
@@ -13,10 +13,36 @@
   name: Прибор ночного видения
   description: Позволяет видеть в полной темноте. Работает на ядерной батарее внутри и совсем не вреден для глаз.
   productEntity: ClothingEyesNightvision
-  cost:
+  discountCategory: rareDiscounts
+  discountDownTo:
     Telecrystal: 2
+  cost:
+    Telecrystal: 4
   categories:
     - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+        - NukeOpsUplink
+
+- type: listing
+  id: UplinkNightvisionNukeOps
+  name: Прибор ночного видения
+  description: Позволяет видеть в полной темноте. Работает на ядерной батарее внутри и совсем не вреден для глаз.
+  productEntity: ClothingEyesNightvision
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 4
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+        - NukeOpsUplink
 
 - type: listing
   id: UplinkClothingEyesThermalVisionMonocular
@@ -45,7 +71,7 @@
   discountDownTo:
     Telecrystal: 6
   cost:
-    Telecrystal: 9
+    Telecrystal: 8
   categories:
     - UplinkWearables
   conditions:


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->

## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
* Убрал ночное зрение с очков термального зрения
* Очки ночного виденья теперь стоят для 4 ТК (нижний порог для скидки - 2 ТК), для ЯО 6 ТК (нижний порог для скидки - 4 ТК)
* Очки термального зрения теперь стоят для 6 ТК (нижний порог для скидки - 4 ТК), для ЯО 8 ТК (нижний порог для скидки - 6 ТК)

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
При включении термального зрения теперь идёт проверка на то, является ли способность встроенной (чтобы тенеморфы и рабы не бегали в темноте, а термальные очки не имели ночного зрения из-за проверки).
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- remove: У очков термального зрения убарно ночное зрение
- tweak: Очки ночного виденья теперь стоят для 4 ТК, для ЯО 6 ТК
- tweak: Очки термального зрения теперь стоят для 6 ТК, для ЯО 8 ТК
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
