### PR TITLE
tweak damage chatting in crit 

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -564,7 +564,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         // Stories-Crit-Speech-Start
         if (_mobStateSystem.IsCritical(source) && _prototype.TryIndex<DamageTypePrototype>("Asphyxiation", out var asphyxiation))
-            _damageable.TryChangeDamage(source, new(asphyxiation, 100), true, false);
+            _damageable.TryChangeDamage(source, new(asphyxiation, 80), true, false);
         // Stories-Crit-Speech-End
 
         var ev = new EntitySpokeEvent(source, message, originalMessage, channel, obfuscatedMessage); // Stories-TTS: Spec symbol sanitize


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Теперь урон при ответе в крите 80
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Чтобы люди писавшие сообщение в крите, не отправлялись в госты.

Пример: после реанимации снова упали в крит, а сообщение спровоцировало смерть.

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: урон при ответе в крите наносит 80 удушья, вместо 100
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl: 
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
