### PR TITLE
Fix KT roles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -129,7 +129,7 @@
 - type: entity
   parent: BasePDA
   id: BaseMedicalPDA
-  abstract: true # Stories-ERT-Health-Analyzer
+  abstract: true
   components:
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -21,7 +21,7 @@
     netsync: false
   - type: Clickable
   - type: AccessReader
-    access: [["Engineering"], ["PrisonEng"]] # [["Engineering"]] # Stories
+    access: [["Engineering"], ["PrisonEng"]] # [["Engineering"]] # Stories-Prison
   - type: InteractionOutline
   - type: Transform
     anchored: true

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -153,7 +153,7 @@
     stateDoorOpen: eng_secure_open
     stateDoorClosed: eng_secure_door
   - type: AccessReader
-    access: [ [ "Engineering" ] ]
+    access: [ [ "Engineering" ], ["PrisonEng"]] # [ [ "Engineering" ] ] # Stories
 
 # Freezer
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -153,7 +153,7 @@
     stateDoorOpen: eng_secure_open
     stateDoorClosed: eng_secure_door
   - type: AccessReader
-    access: [ [ "Engineering" ], ["PrisonEng"]] # [ [ "Engineering" ] ] # Stories
+    access: [ [ "Engineering" ], ["PrisonEng"]] # [ [ "Engineering" ] ] # Stories-Prison
 
 # Freezer
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -197,7 +197,7 @@
   - type: Sprite
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
   - type: AccessReader
-    access: [["Engineering"], ["PrisonEng"]] # [["Engineering"]] # Stories
+    access: [["Engineering"], ["PrisonEng"]] # [["Engineering"]] # Stories-Prison
 
 - type: entity
   parent: CrateBaseSecure

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -197,7 +197,7 @@
   - type: Sprite
     sprite: Structures/Storage/Crates/engicrate_secure.rsi
   - type: AccessReader
-    access: [["Engineering"]]
+    access: [["Engineering"], ["PrisonEng"]] # [["Engineering"]] # Stories
 
 - type: entity
   parent: CrateBaseSecure

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -69,7 +69,7 @@
     boardName: wires-board-name-airalarm
     layoutId: AirAlarm
   - type: AccessReader
-    access: [["Atmospherics"]]
+    access: [["Atmospherics"], ["PrisonEng"]] # [["Atmospherics"]] # Stories
   - type: ContainerFill
     containers:
       board: [ AirAlarmElectronics ]

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -69,7 +69,7 @@
     boardName: wires-board-name-airalarm
     layoutId: AirAlarm
   - type: AccessReader
-    access: [["Atmospherics"], ["PrisonEng"]] # [["Atmospherics"]] # Stories
+    access: [["Atmospherics"], ["PrisonEng"]] # [["Atmospherics"]] # Stories-Prison
   - type: ContainerFill
     containers:
       board: [ AirAlarmElectronics ]

--- a/Resources/Prototypes/_Stories/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Stories/Entities/Objects/Devices/pda.yml
@@ -77,15 +77,16 @@
     state: pda-spengineer
 
 - type: entity
-  parent:
-    - PRISONPDAHeadOfPrison
-    - BaseMedicalPDA
+  parent: BaseMedicalPDA
   id: PRISONPDAMedic
   name: КПК врача тюрьмы
   description: Этот КПК - ваш путь к свободе.
   components:
+  - type: Sprite
+    sprite: _Stories/Objects/Devices/pda.rsi
   - type: Pda
-    id: PRISONIDCardMedic
+    id: PRISONIDCardHeadOfPrison
     state: pda-spmedic
   - type: Icon
+    sprite: _Stories/Objects/Devices/pda.rsi
     state: pda-spmedic

--- a/Resources/Prototypes/_Stories/Roles/Jobs/Prison/prison_engineer.yml
+++ b/Resources/Prototypes/_Stories/Roles/Jobs/Prison/prison_engineer.yml
@@ -19,7 +19,6 @@
   - Prison
   - PrisonEng
   - Maintenance
-  - Engineering
   - External
   # special:
   # - !type:AddImplantSpecial


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
* Удалил обычный инженерный доступ у ИКТ
* Добавил доступ PrisonEng на недостающие объекты
* Починил мед сканер для МКТ (через паррентов путь до спрайта никак не сохранить, чтобы сохранить компоненты базового мед кпк, да и не сильно хуже от этого)

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- fix: Исправлен доступ к воздушной сигнализации у Иженера КТ
- fix: Возвращён МедТек (мед сканер) в кпк Медика КТ
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
