### PR TITLE
Добавить кнопку "Выдать полный доступ" в консоль ID-Карт

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -1,5 +1,5 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-            MinSize="650 500">
+            MinSize="650 500"> <!-- Stories-Access -->
     <BoxContainer Orientation="Vertical">
         <GridContainer Columns="2">
             <GridContainer Columns="3" HorizontalExpand="True">
@@ -31,6 +31,6 @@
             <OptionButton Name="JobPresetOptionButton" />
         </GridContainer>
         <Control Name="AccessLevelControlContainer" />
-        <Button Name="GiveAllAccessButton" Text="Выдать полный доступ" HorizontalAlignment="Right" />
+        <Button Name="GiveAllAccessButton" Text="Выдать полный доступ" HorizontalAlignment="Right" /> <!-- Stories-Access -->
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -1,5 +1,5 @@
 <DefaultWindow xmlns="https://spacestation14.io"
-            MinSize="650 290">
+            MinSize="650 500">
     <BoxContainer Orientation="Vertical">
         <GridContainer Columns="2">
             <GridContainer Columns="3" HorizontalExpand="True">
@@ -31,5 +31,6 @@
             <OptionButton Name="JobPresetOptionButton" />
         </GridContainer>
         <Control Name="AccessLevelControlContainer" />
+        <Button Name="GiveAllAccessButton" Text="Выдать все доступы" HorizontalAlignment="Right" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -31,6 +31,6 @@
             <OptionButton Name="JobPresetOptionButton" />
         </GridContainer>
         <Control Name="AccessLevelControlContainer" />
-        <Button Name="GiveAllAccessButton" Text="Выдать все доступы" HorizontalAlignment="Right" />
+        <Button Name="GiveAllAccessButton" Text="Выдать полный доступ" HorizontalAlignment="Right" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -30,6 +30,8 @@ namespace Content.Client.Access.UI
         // The job that will be picked if the ID doesn't have a job on the station.
         private static ProtoId<JobPrototype> _defaultJob = "Passenger";
 
+        private List<ProtoId<AccessLevelPrototype>> _accessLevels; // Stories-Access
+
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager,
             List<ProtoId<AccessLevelPrototype>> accessLevels)
         {
@@ -38,6 +40,8 @@ namespace Content.Client.Access.UI
             _logMill = _logManager.GetSawmill(SharedIdCardConsoleSystem.Sawmill);
 
             _owner = owner;
+
+            _accessLevels = accessLevels; // Stories-Access
 
             FullNameLineEdit.OnTextEntered += _ => SubmitData();
             FullNameLineEdit.OnTextChanged += _ =>
@@ -52,6 +56,8 @@ namespace Content.Client.Access.UI
                 JobTitleSaveButton.Disabled = JobTitleLineEdit.Text == _lastJobTitle;
             };
             JobTitleSaveButton.OnPressed += _ => SubmitData();
+
+            GiveAllAccessButton.OnPressed += _ => AddAllAccess();
 
             var jobs = _prototypeManager.EnumeratePrototypes<JobPrototype>().ToList();
             jobs.Sort((x, y) => string.Compare(x.LocalizedName, y.LocalizedName, StringComparison.CurrentCulture));
@@ -87,6 +93,25 @@ namespace Content.Client.Access.UI
                 }
             }
         }
+
+        // Stories-Access
+
+        private void AddAllAccess()
+        {
+            ClearAllAccess();
+
+            foreach (var accessLevel in _accessLevels)
+            {
+                if (_accessButtons.ButtonsList.TryGetValue(accessLevel, out var button) && !button.Disabled)
+                {
+                    button.Pressed = true;
+                }
+            }
+
+            SubmitData();
+        }
+
+        // Stories-Access
 
         private void SelectJobPreset(OptionButton.ItemSelectedEventArgs args)
         {

--- a/Resources/Prototypes/_Stories/Access/prison.yml
+++ b/Resources/Prototypes/_Stories/Access/prison.yml
@@ -21,3 +21,7 @@
 - type: accessLevel
   id: Prisoner
   name: Заключенный
+
+- type: accessLevel
+  id: Sss
+  name: Судо лекс

--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client --configuration Tools
+pause

--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,0 +1,2 @@
+@echo off
+dotnet run --project Content.Client --configuration Tools

--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,3 +1,2 @@
 @echo off
 dotnet run --project Content.Client --configuration Tools
-pause

--- a/runclient-Tools.bat
+++ b/runclient-Tools.bat
@@ -1,3 +1,2 @@
 @echo off
-dotnet run --project Content.Client --configuration Tools
-pause
+dotnet run --project Content.Client --configuration Tools 


### PR DESCRIPTION
## О PR
Добавлена возможность выдать полный доступ одной кнопкой

## Почему / Баланс
Для выдачи полного доступа необходимо было некоторое время, в т.ч изза синхронизации, от которой нельзя было слишком быстро выдавать нужные (расширенный либо полный) доступы. Банальное удобство.

## Технические детали

## Медиа

https://github.com/user-attachments/assets/d92bad38-42ae-42e1-9d28-b3d806d2b73b


- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
:cl: be1bright
- add: Добавлена возможность выдать полный доступ одной кнопкой

