### PR TITLE
Fix ancient toolboxes

### DIFF
--- a/Resources/Prototypes/_Stories/Loadouts/passenger.yml
+++ b/Resources/Prototypes/_Stories/Loadouts/passenger.yml
@@ -2,6 +2,7 @@
 - type: loadoutGroup
   id: STPassengerToolbox
   name: stories-loadout-group-passenger-storage
+  minLimit: 0
   loadouts:
   - STToolboxAncient
 
@@ -12,5 +13,5 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: GreyTider
-  equipment:
-    pocket1: STToolboxAncient
+  inhand:
+    - STToolboxAncient


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Снова коммит не сохранил один перед отправой...

- Минимум туллбоксов для пассажиров теперь - 0 (пробный период кончился, пхех)
- Теперь туллбокс появляется в руке, а не в кармане (получался второй рюкзак, неприятная ошибка от меня)

**Changelog**

:cl: Shegare
- fix: Старинный ящик из лодаута появляется в руке, а не в кармане
- fix: Теперь нужно выбрать старинный ящик в лодауте, чтобы появиться с ним