### PR TITLE
Fix events

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -163,7 +163,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 6.5
     earliestStart: 40
     reoccurrenceDelay: 20
     minimumPlayers: 20
@@ -192,7 +192,7 @@
   id: NinjaSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 6
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 20
@@ -241,7 +241,7 @@
   id: RevenantSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 7.5
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -273,8 +273,6 @@
       path: /Audio/Announcements/gasleak_end.ogg # Corvax-Announcements
       params:
         volume: -4
-    earliestStart: 10
-    minimumPlayers: 5
     weight: 8
   - type: GasLeakRule
 
@@ -361,7 +359,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 6
+    weight: 5
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -382,7 +380,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 6
+    weight: 5
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -403,7 +401,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 6
+    weight: 5
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -420,7 +418,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 20
-    weight: 6.5
+    weight: 1.5
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -466,8 +464,8 @@
   components:
   - type: StationEvent
     earliestStart: 35
-    weight: 7.5
-    minimumPlayers: 25
+    weight: 5.5
+    minimumPlayers: 20
     duration: 1
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -21,7 +21,7 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.25
+      prob: 0.5
 
 - type: entity
   id: DeathMatch31
@@ -181,7 +181,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 8
-      playerRatio: 15
+      playerRatio: 10
       blacklist:
         components:
         - AntagImmune
@@ -330,10 +330,10 @@
   parent: BaseGameRule
   components:
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1800 # 30 mins
+    minimumTimeUntilFirstEvent: 1200 # 20 mins
     minMaxEventTiming:
-      min: 1200 # 20 mins
-      max: 3600 # 60 mins
+      min: 600 # 10 mins
+      max: 1800 # 30 mins
     scheduledGameRules: !type:NestedSelector
       tableId: UnknownShuttlesFriendlyTable
 
@@ -345,15 +345,11 @@
   - type: RoundstartStationVariationRule
     rules:
     - id: BasicPoweredLightVariationPass
-      prob: 0.50
     - id: BasicTrashVariationPass
-      prob: 0.50
     - id: SolidWallRustingVariationPass
-      prob: 0.50
     - id: ReinforcedWallRustingVariationPass
-      prob: 0.50
     - id: BasicPuddleMessVariationPass
-      prob: 0.50
+      prob: 0.99
       orGroup: puddleMess
     - id: BloodbathPuddleMessVariationPass
       prob: 0.01

--- a/Resources/Prototypes/_Stories/GameRules/events.yml
+++ b/Resources/Prototypes/_Stories/GameRules/events.yml
@@ -199,7 +199,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
-    weight: 6.5
+    weight: 6
     duration: 50
     minimumPlayers: 30
   - type: VentCrittersRule


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
- Теперь шансы и условия ивентов соответствуют оффовским (у ванильного Корвакса такие же)
- Приоритет СПАФа снижен, так как его условия взяты с короля крыс (да и они примерно одинаковы по концепции и силе), но шанс его появления почему-то как у Дракона

## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Уже давно игроки жалуются что у нас спамит ивентами
![Discord_dr5oUI89Jf](https://github.com/user-attachments/assets/65196b51-279e-48b7-80be-717f80e21f34)
![Discord_aZY49p4rTp](https://github.com/user-attachments/assets/cf3a0996-2af4-40e2-a585-36b1c98a252b)
![image](https://github.com/user-attachments/assets/b0d317eb-ae71-4d65-9ed9-78c77680e180)

И это одно дело. Но когда даже на других серверах говорят что у нас бешенные спавны, то тут уже какой-то сюр
![Discord_H4SWpVURRP](https://github.com/user-attachments/assets/c0be6389-99c4-4d8d-a3df-e78895789202)

Ну и думаю не надо объяснять что спам агрессивными ивентами не идёт на пользу РП. А также мешает даже обычным антагам
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Скорее всего дело в том, что у мелких ивентов приоритет выше, но ниже условия для спавна и вместо того чтобы заспавнить один крупный ивент типа BaseStationEventLongDelay (переодичность спавна от 40 до 60 минут), он вызывает BaseStationEventShortDelay (переодичность спавна от 10 до 20 минут), из-за чего каждые 15 минут пауки, слаймы и т.д. Код нереально опустить при таких условиях. 
Также игроки лишаются возможности на антаге поиграть, так как слаймы и подобное в высшем приоритете

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- fix: Исправлены условия спавна игровых событий
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
