### PR TITLE
Rebalance RCD costs

### DIFF
--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -165,7 +165,7 @@
   sprite: /Textures/Interface/Radial/RCD/airlock.png
   mode: ConstructObject
   prototype: Airlock
-  cost: 4
+  cost: 5 # 4 # Stories
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera
@@ -177,7 +177,7 @@
   sprite: /Textures/Interface/Radial/RCD/glass_airlock.png
   mode: ConstructObject
   prototype: AirlockGlass
-  cost: 4
+  cost: 5 # 4 # Stories
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera
@@ -189,7 +189,7 @@
   sprite: /Textures/Interface/Radial/RCD/firelock.png
   mode: ConstructObject
   prototype: Firelock
-  cost: 4
+  cost: 5 # 4 # Stories
   delay: 3
   collisionMask: FullTileMask
   rotation: Camera


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Повышена стоимость зарядов РСУ на двери, стеклянные двери и пожарные шлюзы
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Зачем это нам:
- Не будет банов за "Нечестную игру". Так как это самые прочные констрункции в РСУ за свою цену, к тому же дверям можно вырезать безопасный режим и таймер, тем самым защищая проходы (так как опять же они прочнее обычных стен) от ЯО

Почему не оффам:
- У них нет Стража Клинка и строгих наказаний, поэтому любые методы противодействия ЯО будут валидны, даже нестандартные ( А всё что у нас не стандартно, необычно и не прописано в правилах - чаще всего карается. И я не могу на вики прописать правила РСУ XD )

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: Постройка шлюзов теперь тратит 5 зарядов РСУ, вместо 4
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
