### PR TITLE
Esword antimeta

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1392,8 +1392,8 @@
   description: New Sandy-Cat plastic sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
     - type: EnergySword
-      colorOptions:
-        - DodgerBlue
+      #colorOptions:    Sroties - commented out
+      #  - DodgerBlue
     - type: ItemToggle
       soundActivate:
         path: /Audio/Weapons/ebladeon.ogg
@@ -1403,7 +1403,7 @@
       activeSound:
         path: /Audio/Weapons/ebladehum.ogg
     - type: Sprite
-      sprite: Objects/Fun/toy_sword.rsi
+      sprite: Objects/Weapons/Melee/e_sword.rsi     #Stories - was Objects/Fun/toy_sword.rsi
       layers:
         - state: e_sword
         - state: e_sword_blade
@@ -1413,7 +1413,7 @@
           map: [ "blade" ]
     - type: Item
       size: Small
-      sprite: Objects/Fun/toy_sword.rsi
+      sprite: Objects/Weapons/Melee/e_sword-inhands.rsi     #Stories - was Objects/Fun/toy_sword.rsi
     - type: UseDelay
       delay: 1.0
     - type: PointLight

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1391,7 +1391,7 @@
   name: toy sword
   description: New Sandy-Cat plastic sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
-    - type: EnergySword # Stories - AntiMeta
+    - type: EnergySword # Stories-AntiMeta
       # colorOptions:
       #   - DodgerBlue
     - type: ItemToggle

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1391,7 +1391,7 @@
   name: toy sword
   description: New Sandy-Cat plastic sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
-    - type: EnergySword # Sroties - AntiMeta
+    - type: EnergySword # Stories - AntiMeta
       # colorOptions:
       #   - DodgerBlue
     - type: ItemToggle

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1391,9 +1391,9 @@
   name: toy sword
   description: New Sandy-Cat plastic sword! Comes with realistic sound and full color! Looks almost like the real thing!
   components:
-    - type: EnergySword
-      #colorOptions:    Sroties - commented out
-      #  - DodgerBlue
+    - type: EnergySword # Sroties - AntiMeta
+      # colorOptions:
+      #   - DodgerBlue
     - type: ItemToggle
       soundActivate:
         path: /Audio/Weapons/ebladeon.ogg
@@ -1403,7 +1403,7 @@
       activeSound:
         path: /Audio/Weapons/ebladehum.ogg
     - type: Sprite
-      sprite: Objects/Weapons/Melee/e_sword.rsi     #Stories - was Objects/Fun/toy_sword.rsi
+      sprite: Objects/Weapons/Melee/e_sword.rsi # Stories-AntiMeta
       layers:
         - state: e_sword
         - state: e_sword_blade
@@ -1413,7 +1413,7 @@
           map: [ "blade" ]
     - type: Item
       size: Small
-      sprite: Objects/Weapons/Melee/e_sword-inhands.rsi     #Stories - was Objects/Fun/toy_sword.rsi
+      sprite: Objects/Weapons/Melee/e_sword-inhands.rsi # Stories-AntiMeta
     - type: UseDelay
       delay: 1.0
     - type: PointLight


### PR DESCRIPTION
## О PR
Поменял спрайт игрушечного меча на спрайт энергомеча, а так же снял ограничения на цвета (раньше игрушка всегда была синей, теперь копирует поведение есворда)

## Почему / Баланс
Антимета. Имя поменяли, а спрайт забыли. Теперь игрушку от настоящего можно отличить лишь осмотрев наносимый урон, для чего нужно держать меч непосредственно в руке (ну, или же получить им по лицу).
Так же предложка в дискорде: https://discord.com/channels/1111698541841240164/1344207190357180508

## Технические детали
4 строчки в прототипе.

## Медиа
![изображение](https://github.com/user-attachments/assets/9a484d14-1dd1-47a4-a870-39907a06680b)
"Это игрушка, честно!"

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**

:cl:
- tweak: Игрушечный энергомеч теперь выглядит как настоящий
