### PR TITLE
Update garrote system

### DIFF
--- a/Content.Server/_Stories/Garrote/GarroteSystem.cs
+++ b/Content.Server/_Stories/Garrote/GarroteSystem.cs
@@ -60,7 +60,7 @@ public sealed class GarroteSystem : SharedGarroteSystem
             return;
         }
 
-        if (GetEntityDirection(userTransform) != GetEntityDirection(targetTransform) && _actionBlocker.CanInteract(args.Target.Value, null))
+        if (comp.CheckDirection && GetEntityDirection(userTransform) != GetEntityDirection(targetTransform) && _actionBlocker.CanInteract(args.Target.Value, null))
         {
             var message = Loc.GetString("garrote-component-must-be-behind", ("target", args.Target));
             _popupSystem.PopupEntity(message, args.Target.Value, args.User);

--- a/Content.Shared/_Stories/Weapons/Special/Garrote/GarroteComponent.cs
+++ b/Content.Shared/_Stories/Weapons/Special/Garrote/GarroteComponent.cs
@@ -6,7 +6,26 @@ namespace Content.Shared._Stories.Weapons.Special.Garrote;
 public sealed partial class GarroteComponent : Component
 {
     [DataField("doAfterTime")]
-    public TimeSpan DoAfterTime = TimeSpan.FromSeconds(0.5f);
+    public TimeSpan DoAfterTime
+    {
+        get { return doAfterTime; }
+        set
+        {
+            if (value.Seconds <= 0.5f)
+            {
+                doAfterTime = value;
+                DurationStatusEffects = TimeSpan.FromSeconds(1f);
+            }
+            else
+            {
+                doAfterTime = value;
+                DurationStatusEffects = value.Add(TimeSpan.FromSeconds(0.5f));
+            }
+        }
+    }
+
+    private TimeSpan doAfterTime = TimeSpan.FromSeconds(0.5f);
+    public TimeSpan DurationStatusEffects = TimeSpan.FromSeconds(1f);
 
     [DataField("damage")]
     public DamageSpecifier Damage = new()
@@ -19,4 +38,7 @@ public sealed partial class GarroteComponent : Component
 
     [DataField("maxUseDistance")]
     public float MaxUseDistance = 0.5f;
+
+    [DataField("checkDirection")]
+    public bool CheckDirection = true;
 }

--- a/Content.Shared/_Stories/Weapons/Special/Garrote/SharedGarroteSystem.cs
+++ b/Content.Shared/_Stories/Weapons/Special/Garrote/SharedGarroteSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Speech.Muting;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._Stories.Weapons.Special.Garrote;
 
@@ -22,7 +23,9 @@ public abstract class SharedGarroteSystem : EntitySystem
 
     private void OnGarroteDoAfter(EntityUid uid, GarroteComponent comp, GarroteDoAfterEvent args)
     {
-        if (args.Target == null || !TryComp<MobStateComponent>(args.Target, out var mobState))
+        if (args.Target == null
+            || !TryComp<MobStateComponent>(args.Target, out var mobState)
+            || !TryComp<StatusEffectsComponent>(args.Target, out var statusEffectsComp))
             return;
 
         if (args.Cancelled || mobState.CurrentState != MobState.Alive)
@@ -30,8 +33,9 @@ public abstract class SharedGarroteSystem : EntitySystem
 
         _damageable.TryChangeDamage(args.Target, comp.Damage, origin: args.User);
 
-        _stun.TryStun(args.Target.Value, 2 * comp.DoAfterTime, true);
-        _statusEffect.TryAddStatusEffect<MutedComponent>(args.Target.Value, "Muted", 2 * comp.DoAfterTime, refresh: true);
+        _stun.TryStun(args.Target.Value, comp.DurationStatusEffects, true);
+        _statusEffect.TryAddStatusEffect<MutedComponent>(args.Target.Value, "Muted", comp.DurationStatusEffects, refresh: true);
+        Dirty(args.Target.Value, statusEffectsComp);
 
         args.Repeat = true;
     }


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Поковырял компоненты и ситемы удавки

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
- Можно отключить через переменную проверку на то, находится ли юзер за спиной таргета
- Теперь при любом значении DoAfterTime на клиенте игроки будут успевать станиться, прежде чем начать убегать 
  (если пытаться ходить во время удушения, то не будет тепать при любых значениях DoAfterTime)
- Решена проблема что если сильно увеличить длительность DoAfterTime, то стан длился также очень долго, даже если никто не удушает. (20 секунд DoAfterTime = 40 секунд стана. Когда по задумке стан не должен длиться дольше, либо сильно дольше чем применяется удавка)
- Добавил синхронизацию эффектов (мут и стан) с таргетом - надеюсь правильно реализовал?
