### PR TITLE
Корректировка шансов в режиме Секрет

### DIFF
--- a/Resources/Prototypes/_Stories/secret_weights.yml
+++ b/Resources/Prototypes/_Stories/secret_weights.yml
@@ -1,10 +1,10 @@
 - type: weightedRandom
   id: StoriesSecret
   weights:
-    Traitor: 0.60
+    Traitor: 0.45
     Nukeops: 0.20
     Extended: 0.10
-    Survival: 0.10
+    Survival: 0.04
     KesslerSyndrome: 0.05
     Revolutionary: 0.05
     Shadowling: 0.05


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Сейчас если сложить все шансы, то получится 121%, когда должно быть в сумме ровно 100%
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
- Убавил шанс на режим предателей, так как всё равно самый высокий процент выпадения
- Снизил шанс на режим виживания, так как и без того каждый раунд как выживание из-за спама игровыми ивентами на агрессивную фауну

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: Незначительно снижены шансы на режим Предателей и на Выживание.
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
