### PR TITLE
Обновление системы ночного зрения

### DIFF
--- a/Content.Server/_Stories/Nightvision/NightvisionSystem.cs
+++ b/Content.Server/_Stories/Nightvision/NightvisionSystem.cs
@@ -1,7 +1,5 @@
 using Content.Shared.Actions;
-using Content.Shared.GameTicking;
 using Content.Shared.Inventory.Events;
-using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using Content.Shared._Stories.Nightvision;
 
@@ -11,6 +9,7 @@ public sealed class NightvisionSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -30,7 +29,11 @@ public sealed class NightvisionSystem : EntitySystem
             return;
 
         if (component.Enabled && !HasComp<NightvisionComponent>(args.Equipee) && (args.Slot == "eyes"))
-            AddComp<NightvisionComponent>(args.Equipee);
+        {
+            var comp = _factory.GetComponent<NightvisionComponent>();
+            comp.ToggleOnSound = component.ToggleOnSound;
+            AddComp(args.Equipee, comp);
+        }
     }
     private void OnStartUp(EntityUid uid, NightvisionComponent component, ComponentStartup args)
     {

--- a/Content.Shared/_Stories/Nightvision/NightvisionComponent.cs
+++ b/Content.Shared/_Stories/Nightvision/NightvisionComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Actions;
-using Content.Shared.Eye.Blinding.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
@@ -11,12 +10,15 @@ public sealed partial class NightvisionComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("enabled"), AutoNetworkedField]
     public bool Enabled { get; set; } = false;
+
     [DataField]
     public string ToggleAction = "ToggleNightvisionAction";
+
     [DataField, AutoNetworkedField]
     public EntityUid? ToggleActionEntity;
+
     [DataField("toggleOnSound")]
-    public SoundSpecifier? ToggleOnSound = new SoundPathSpecifier("/Audio/_Stories/Misc/night_vision.ogg");
+    public SoundSpecifier? ToggleOnSound;
 }
 
 [RegisterComponent]
@@ -25,5 +27,8 @@ public sealed partial class NightvisionClothingComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("enabled")]
     public bool Enabled { get; set; } = true;
+
+    [DataField("toggleOnSound")]
+    public SoundSpecifier? ToggleOnSound;
 }
 public sealed partial class ToggleNightvisionEvent : InstantActionEvent { }

--- a/Content.Shared/_Stories/Nightvision/SharedNightvisionSystem.cs
+++ b/Content.Shared/_Stories/Nightvision/SharedNightvisionSystem.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 namespace Content.Shared._Stories.Nightvision;
@@ -17,6 +18,6 @@ public sealed class SharedNightvisionSystem : EntitySystem
             return;
         component.Enabled = !component.Enabled;
         if (component.Enabled && component.ToggleOnSound != null)
-            _audio.PlayLocal(component.ToggleOnSound, uid, uid);
+            _audio.PlayPvs(component.ToggleOnSound, uid, AudioParams.Default.WithMaxDistance(2f));
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -86,7 +86,6 @@
       interactFailureSound:
         path: /Audio/Effects/bite.ogg
     - type: Nightvision # Stories
-      toggleOnSound: null # Stories
 
 - type: entity
   parent: BaseMobCarp

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -155,7 +155,6 @@
   - type: Puller
     needsHands: false
   - type: Nightvision # Stories - start
-    toggleOnSound: null
   - type: TTS
     voice: ranrak # Stories - end
 

--- a/Resources/Prototypes/_Stories/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Stories/Entities/Clothing/Eyes/glasses.yml
@@ -34,6 +34,7 @@
   description: Позволяет видеть в полной темноте. Работает на ядерной батарее внутри и совсем не вреден для глаз.
   components:
   - type: NightvisionClothing # Space Stories
+    toggleOnSound: /Audio/_Stories/Misc/night_vision.ogg
   - type: Sprite
     sprite: _Stories/Clothing/Eyes/Glasses/nvg.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
- Теперь звук активации очков ночного зрения не захардкожен
- Писк при активации очков ночного зрения слышен на расстоянии 2 тайлов

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: Теперь использование очков ночного зрения слышно на расстоянии 2 тайлов.
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
