### PR TITLE
Фиксы Бригмедика

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -462,8 +462,8 @@
     layers:
     - state: default
     - state: idbrigmedic
-    - type: PresetIdCard # Stories-Brigmedic
-      job: STBrigmedic
+  - type: PresetIdCard # Stories-Brigmedic
+    job: STBrigmedic
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -338,7 +338,7 @@
     stateDoorOpen: armory_open
     stateDoorClosed: brigmedic_door
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["Security"]] # [["Medical"]] # Stories-Brigmedic
 
 # Security Officer
 - type: entity


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
- Не показывался на мониторинге экипажа, из-за того что в прототипе айди карты были лишние отступы и из-за этого не работал компонент PresetIdCard
- Теперь ящик Бригмеда могут открыть сотрудники СБ (он как никак в отделе СБ и там есть медикаменты, которые могут быть важны)
