### PR TITLE
Время открытия Вардена

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 108000 #50 hrs # Corvax-RoleTime
+      time: 72000 #20 hrs # Stories-RoleTime
   weight: 5
   startingGear: WardenGear
   icon: "JobIconWarden"


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Изменил время открытия вардена с 50 часов до 20
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Время открытия офицера СБ - 10 часов в отделе СБ
Время открытия ГСБ - 30 часов в отделе СБ
Время открытия Вардена - 50 часов в отделе СБ?! 
P.S. окей, там на самом деле 30 часов, но всё равно странно что у ГСБ столько же, стоит Вардену уменьшить количество часов открытия (КЗ щас не такое сложное и играть вообще без Вардена такое себе), либо увеличить время в СБ для открытия ГСБ

Либо тогда уж повысить время открытия роли ГСБ, чтобы это было логично и пропорционально

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: Теперь чтобы открыть Вардена нужно 20 часов в отделе СБ.
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
