### PR TITLE
Исправление призрачных состояний Инквизитора и Тенеморфа

### DIFF
--- a/Resources/Prototypes/_Stories/Entities/Mobs/Ghosts/shadowling.yml
+++ b/Resources/Prototypes/_Stories/Entities/Mobs/Ghosts/shadowling.yml
@@ -1,9 +1,7 @@
 - type: entity
   id: MobShadowlingGhost
   name: тенеморф
-  parent:
-  - BaseMob
-  - MobDamageable
+  parent: BaseMobJaunt
   description: Очень страшный.
   components:
   - type: ZombieImmune
@@ -36,8 +34,6 @@
   - type: MindContainer
   - type: InputMover
   - type: MobMover
-  - type: Input
-    context: "ghost"
   - type: MovementSpeedModifier
     baseWalkSpeed: 15
     baseSprintSpeed: 15
@@ -46,17 +42,6 @@
     drawdepth: Ghosts
   - type: Clickable
   - type: InteractionOutline
-  - type: Physics
-    bodyType: KinematicController
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.40
-        density: 80
-        mask:
-        - GhostImpassable
   - type: MovementIgnoreGravity
   - type: Examiner
   - type: NoSlip

--- a/Resources/Prototypes/_Stories/Entities/Mobs/inquisitor.yml
+++ b/Resources/Prototypes/_Stories/Entities/Mobs/inquisitor.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: MobInquisitorGhost
+  parent: BaseMobJaunt
   name: инквизитор
   description: Очень страшный.
   components:
@@ -11,8 +12,6 @@
   - type: MindContainer
   - type: InputMover
   - type: MobMover
-  - type: Input
-    context: "ghost"
   - type: MovementSpeedModifier
     baseWalkSpeed: 15
     baseSprintSpeed: 15
@@ -27,17 +26,6 @@
     allowed:
     - Stun
   - type: InteractionOutline
-  - type: Physics
-    bodyType: KinematicController
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.40
-        density: 80
-        mask:
-        - GhostImpassable
   - type: MovementIgnoreGravity
   - type: Damageable
     damageContainer: Biological


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Надеюсь ничего не сломалось (на локалке всё нормально было)

Исправлен баг с тем что призраки (админы / мёртвые игроки) толкали призрачные формы Инквиза и Теника

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- fix: Призраки больше не воздействуют на Инквизитора и Тенеморфа, когда они в состоянии призрачного перемещения (теневой призрак, теневой шаг).
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
