### PR TITLE
Фиксы общения в крите

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -572,7 +572,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         // Stories-Crit-Speech-Start
         if (_mobStateSystem.IsCritical(source) && _prototype.TryIndex<DamageTypePrototype>("Asphyxiation", out var asphyxiation))
-            _damageable.TryChangeDamage(source, new(asphyxiation, 80), true, false);
+            _damageable.TryChangeDamage(source, new(asphyxiation, 100), true, false);
         // Stories-Crit-Speech-End
 
         var ev = new EntitySpokeEvent(source, message, originalMessage, channel, obfuscatedMessage); // Stories-TTS: Spec symbol sanitize

--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -25,7 +25,7 @@ public sealed class DamageForceSaySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<DamageForceSayComponent, StunnedEvent>(OnStunned);
-        SubscribeLocalEvent<DamageForceSayComponent, MobStateChangedEvent>(OnMobStateChanged);
+        // SubscribeLocalEvent<DamageForceSayComponent, MobStateChangedEvent>(OnMobStateChanged); // Stories-Crit-Speech
 
         // need to raise after mobthreshold
         // so that we don't accidentally raise one for damage before one for mobstate


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
- Если упасть крит, то сообщение из чата не будет автоматически отправлено.
- Урон при разговоре в крите снова наносит 100 урона удушьем.
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Откатил https://github.com/MetalSage/space-stories-14/pull/45, так как исправил то по какой причине я изменял урон от удушья в крите, а именно - из-за того что когда пишешь во время избиения это автосмерть или если тебя лечили, ты что-то хотел сказать спасителю, а потом должен был на секунду уйти в крит из-за восстановления дыхания, но откис из-за того что игра за тебя отправила сообщение в чат и спровоцировала смерть
## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Просто изменил хардкод урон и закомментировал подписку на автоотправку сообщения при MobStateChangedEvent
## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->
### До:
https://github.com/user-attachments/assets/9c09b4f4-3672-42b0-80d1-477e4cf54177

### После (сообщение я сам отправил):
https://github.com/user-attachments/assets/94de25f9-ecc7-496e-9272-954fa5cdf926

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- tweak: Если упасть крит, то сообщение из чата не будет автоматически отправлено.
- tweak: Урон при разговоре в крите снова наносит 100 урона удушьем.
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
