### PR TITLE
Ослабление стан меты против ЯО

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -130,8 +130,8 @@
         Caustic: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.35
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.45
+  - type: StaminaResistance # Stories
+    damageCoefficient: 0.75
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -536,8 +536,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.75
+  - type: StaminaResistance # Stories
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -598,8 +598,8 @@
     damageCoefficient: 0.2
   - type: FireProtection
     reduction: 0.8
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance # Stories
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -634,8 +634,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance # Stories
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -668,8 +668,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.3
-  #- type: StaminaResistance # Should not have stamina resistance, this is purely so people know it was not forgotten.
-  #  damageCoefficient: 0.99
+  - type: StaminaResistance # Stories
+    damageCoefficient: 0.99
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Коммит из [апстрима](https://github.com/MetalSage/space-stories-14/pull/199)

<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
![Discord_eWDtpu6Z4l](https://github.com/user-attachments/assets/05962ea6-e444-4600-82bb-19a7872b5be2)

Разве что решил ослабить рейдерку, в отличие от оффовской версии, так как у нас для лон опера это и так маст хев

Оффицальный разработчик о стан резистах:
![image](https://github.com/user-attachments/assets/764c6536-abc8-4969-905d-17f3551b5edb)

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- add: Ядерным оперативникам добавлены сопротвиления станам:
  -  Рейдерский костюм, скафандры ЯО и скафандр медика ЯО - 25%
  - Элитный скафандр, скафандр командира ЯО - 40%
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
