### PR TITLE
Фикс закрытия роли кадета СБ

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -8,7 +8,7 @@
       time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 18000 #5 hrs
+      time: 72000 # 20 hrs # Stories-RoleTime
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
В https://github.com/MetalSage/space-stories-14/pull/199 время закрытия роли у оффов было уменьшенно. Из-за того что на `DepartmentTimeRequirement` не было маркировки я не увидел конфликт и получилось что получилось
## Почему / Баланс
<!-- Почему это было изменено? Укажите здесь любые обсуждения или вопросы. Пожалуйста, обсудите, как это повлияет на игровой баланс. -->
Фиксит:
![image](https://github.com/user-attachments/assets/697c130f-717d-43be-9864-357c3785861b)

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl: Shegare
- fix: Кадет СБ больше не закрывается слишком рано, другие роли СБ снова возможно открыть.
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
