### PR TITLE
Возможность наносить урон картами при броске

### DIFF
--- a/Resources/Prototypes/_Stories/Entities/Objects/Fun/cards.yml
+++ b/Resources/Prototypes/_Stories/Entities/Objects/Fun/cards.yml
@@ -12,7 +12,33 @@
   - type: Tag
     tags:
     - STCard
-
+  - type: EmbeddableProjectile
+    sound:
+      params:
+        volume: -1
+      path: /Audio/Weapons/star_hit.ogg
+    removalTime: 0.5
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 2
+        Piercing: 1
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PolygonShape
+          radius: 0.1
+          vertices:
+          - -0.18,-0.23
+          - 0.18,-0.23
+          - 0.18,0.23
+          - -0.18,0.23
+        density: 5
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
 # Clubs
 - type: entity
   parent: STCardBase


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
Теперь карты можно кидать как звёзды ниндзя.

## Почему / Баланс
Веселье.

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->

## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
:cl: bebright
- add: Теперь игральные карты могут навредить при броске.
