### PR TITLE
Удаление Кайло из таблицы событий

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -44,7 +44,6 @@
     #- id: WizardSpawn 
     - id: SpafMigration
     - id: InquisitorSpawn
-    - id: KyloSpawn
     # Stories End
 
 - type: entity


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
Видимо паузы между ивентами вообще может не быть -_-
Говорили что сразу 2 инквиза было, как раз 2 вариации - Кайло и обычный
В общем между ними и так разница только во внешке, так что можно сказать что Кайло это уникальный конет донатерам

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
no cl
<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
