### PR TITLE
Исправление ниндзя спонсоров

### DIFF
--- a/Content.Server/_Stories/Partners/SpecialRolesSystem.cs
+++ b/Content.Server/_Stories/Partners/SpecialRolesSystem.cs
@@ -33,7 +33,6 @@ public sealed class SpecialRolesSystem : EntitySystem
     private const string DefaultTraitorRule = "Traitor";
     private const string DefaultShadowlingRule = "Shadowling";
     // Призрачные роли
-    private const string DefaultNinjaRule = "NinjaSpawn";
     private const string DefaultInquisitorRule = "InquisitorSpawn";
     private const string DefaultKyloRule = "KyloSpawn";
 
@@ -171,9 +170,6 @@ public sealed class SpecialRolesSystem : EntitySystem
                 break;
             case DefaultThiefRule:
                 _antag.ForceMakeAntag<ThiefRuleComponent>(session, prototype.GameRule);
-                break;
-            case DefaultNinjaRule:
-                _antag.ForceMakeAntag<SpaceSpawnRuleComponent>(session, prototype.GameRule);
                 break;
             case DefaultInquisitorRule:
                 _antag.ForceMakeAntag<InquisitorRuleComponent>(session, prototype.GameRule);


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
<!-- Что вы изменили в этом PR? -->
<img width="993" height="88" alt="изображение" src="https://github.com/user-attachments/assets/c3f59bf7-56c4-4d6f-9a59-eddd51668a1c" />

## Технические детали
<!-- Если это изменение кода, кратко опишите на высоком уровне, как работает ваш новый код. Это облегчит рецензирование. -->
Если появится Крысиный король и Древний борг, и отработает код
```
case DefaultNinjaRule:
    _antag.ForceMakeAntag<SpaceSpawnRuleComponent>(session, prototype.GameRule);
    break;
```
То мы будем всё время становится Древним боргом из-за `SpaceSpawnRuleComponent`

Но если появится Крысиный король и Древний борг, и отработает код
```
default:
  _antag.ForceMakeAntag<RatKingComponent>(session, prototype.GameRule);
  break;
```
То мы почему-то не будем становиться Крысиный королём, а будем становиться ниндзя...

В общем я хер знает почему так, поэтому откатил изменение с кодом ниндзя. 
С Инквизом и Кайло по идее такого бага не должно быть, так как у них свои `RuleComponent`