### PR TITLE
Фикс корпиумов

### DIFF
--- a/Resources/Prototypes/_Stories/Reagents/corpium.yml
+++ b/Resources/Prototypes/_Stories/Reagents/corpium.yml
@@ -19,7 +19,7 @@
           reagent: STCorpium
           max: 58
       - !type:AdjustTemperature
-        amount: 6000
+        amount: 1200
         conditions:
         - !type:ReagentThreshold
           reagent: STCorpium


### PR DESCRIPTION
<!-- Пожалуйста, прочитайте эти рекомендации перед тем, как открыть свой PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст между стрелками является комментарием - он не будет виден на вашем PR. -->

## О PR
Уменьшил количество температуры, а следовательно и ожогов выдаваемых существам из за вируса корпиума.

## Почему / Баланс
1) Суть корпиума - призвать потомство, но из за большого количества температуры накидываемой на существ происходили смешные ситуации, когда большинство жертв вируса просто сгорали.
2) Теперь можно будет заражать ВСЕХ животных, а не только избранных (тех что могли пережить ожоги)

## Технические детали
2 цифры в прототипе.

## Медиа
<!--
К PR, вносящим внутриигровые изменения (добавление одежды, предметов, новых возможностей и т.д.), необходимо прикладывать медиа, демонстрирующие изменения.
Небольшие исправления/рефакторы не рассматриваются.
Любые медиаматериалы могут быть использованы в отчетах о проделанной работе в SS14, с указанием четких заслуг.

Если вы не уверены в том, что для вашего PR требуется медиа, обратитесь к сопровождающему.

Поставьте галочку в поле ниже, чтобы подтвердить, что вы действительно видели это (поставьте X в скобках, например [X]):
-->

- [x] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре

**Changelog**
<!--
Чтобы игроки знали о новых возможностях и изменениях, которые могут повлиять на их игру, добавьте запись в Changelog. Пожалуйста, ознакомьтесь с правилами составления Changelog, расположенными по адресу: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog.
-->
:cl:
- fix: Уменьшено количество ожогов, выдаваемых вирусом корпиума.

<!--
Убедитесь, что вы убрали этот шаблон Changelog из блока комментариев, чтобы он отображался.
:cl:
- add: Добавлена радость!
- remove: Удалено развлечение!
- tweak: Изменено развлечение!
- fix: Исправлено развлечение!
