### PR TITLE
Исправление бага выдачи миму аварийного набора

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -83,6 +83,12 @@
     - Human
     - Reptilian
     - Vulpkanin
+    # Stories-Start
+    - Kidan
+    - Avali
+    - Felinid
+    - Rodentia
+    # Stories-End
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth


### PR DESCRIPTION
## О PR
Ранее при выборе не официальной сторисовской расы (авали, родентия, фелинид, кидан) для игры за мима, в рюкзаке не появлялся аварийный набор. Данный ПР исправляет эту недоработку.

## Почему / Баланс
Это явно не должно было так работать. К исправлению подтолкнула публикация о данном баге в соответсвующем канале в дискорде: https://discord.com/channels/1111698541841240164/1493004043679826074 .

## Технические детали
В loadoutEffectGroup с id: OxygenBreatherMime в - !type:SpeciesLoadoutEffect в поле species были добавлены:
    - Kidan
    - Avali
    - Felinid
    - Rodentia
(Stories-Start и Stories-End в комментариях указаны)
До этого в этом поле были указаны только официальные расы, и как следствие аварийный набор появлялся только при выборе их.

## Медиа
- [ ] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре.

**Changelog**

@JustGiveMeALaserSword
- fix: Исправлен баг, из-за которого при выборе сторисовской расы (авали, родентия, фелинид, кидан) у мима в рюкзаке не появлялся аварийный набор: https://discord.com/channels/1111698541841240164/1493004043679826074 .