### PR TITLE
Исправление бага отсутствия ТТС голоса после клонирования

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -20,6 +20,7 @@
   - RandomPrice
   - TemperatureDamage
   - TemperatureSpeed
+  - TTS # Stories-TTS
   # traits
   # - LegsParalyzed (you get healed)
   - Unholy # Stories-Pontific


### PR DESCRIPTION
## О PR
Ранее при клонировании, компонент TTSComponent и его содержимое (значение поля Voice (в игре VoicePrototypeId)) не дублировались в новое тело, в следствии чего клонированное тело становилось "немым" (теряло TTS голос озвучки). Данный ПР исправляет эту недоработку.

## Почему / Баланс
Это явно не должно было так работать. К исправлению подтолкнула публикация о данном баге в соответствующем канале в дискорде: https://discord.com/channels/1111698541841240164/1489674212947005590.

## Технические детали
В cloningSettings с id: Body в список компонентов был добавлен:
`  - TTS`
(Stories-TTS в комментарии указан)

## Медиа
- [x] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре:
(Первый скриншот демонстрирует то, как это было ранее; второй демонстрирует эффект изменения)
<img width="622" height="371" alt="Screenshot_325" src="https://github.com/user-attachments/assets/f758d368-3d0b-49be-80ce-9999455f6e84" />
<img width="622" height="367" alt="Screenshot_326" src="https://github.com/user-attachments/assets/8be9f605-6185-40ff-8d96-3098ad4e078a" />

@JustGiveMeALaserSword
**Changelog**
- fix: Исправлен баг, из-за которого после клонирования сущность теряла свой VoicePrototypeId в TTSComponent (теряла TTS голос озвучки): https://discord.com/channels/1111698541841240164/1489674212947005590.