### PR TITLE
Исправление бага метаболизма арахнидов

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -493,7 +493,7 @@
       - !type:PopupMessage
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Animal, Vox ]
+          type: [ Animal, Arachnid, Vox ]
           inverted: true
         type: Local
         visualType: MediumCaution
@@ -503,12 +503,12 @@
         probability: 0.1
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Animal, Vox, Plant ]
+          type: [ Animal, Arachnid, Vox, Plant ]
           inverted: true
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Animal, Vox, Plant ]
+          type: [ Animal, Arachnid, Vox, Plant ]
           inverted: true
         damage:
           types:
@@ -523,7 +523,7 @@
       - !type:AdjustReagent
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Animal ]
+          type: [ Animal, Arachnid ]
         reagent: Protein
         amount: 0.5
       - !type:AdjustReagent

--- a/Resources/Prototypes/_Stories/Reagents/gases.yml
+++ b/Resources/Prototypes/_Stories/Reagents/gases.yml
@@ -197,6 +197,11 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
+          type: [ Arachnid ]
+        factor: 5
+      - !type:Oxygenate
+        conditions:
+        - !type:MetabolizerTypeCondition
           type: [ Rat ]
         factor: 5
       - !type:Oxygenate


### PR DESCRIPTION
## О PR
У некоторых внутренних органов арахнидов уникальный тип метаболизма (Arachnid), из-за этого TG газ плюоксий не позволял эффективно дышать им так как данный тип метаболизма не был указан в нем, тоже относится к реагенту непрожаренные животные протеины (UncookedAnimalProteins), у арахнидов он не усваивался, хотя должен был (как у животных с метаболизмом Animal). Данный ПР исправляет обе недоработки.

## Почему / Баланс
Касательно плюоксия - это явно не должно было так работать, насчет непрожаренных животных протеинов - не уверен, но вроде как раньше арахниды могли их усваивать. К исправлению подтолкнула публикация о данном баге в соответствующем канале в дискорде: https://discord.com/channels/1111698541841240164/1508776442958188645.

## Технические детали
в reagent с id: STPluoxium в metabolisms: Respiration: effects: был добавлен:
      - !type:Oxygenate
        conditions:
        - !type:MetabolizerTypeCondition
          type: [ Arachnid ]
        factor: 5

в UncookedAnimalProteins с id: UncookedAnimalProteins в некоторых местах было добавлено упоминание метаболизма с id: Arachnid для нивелирования отрицательных эффектов от метаболизации реагента

## Медиа
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре
<img width="527" height="326" alt="Screenshot_386" src="https://github.com/user-attachments/assets/8a8dc965-5849-4708-b48f-ef619479a787" />

**Changelog**
@JustGiveMeALaserSword
- fix: воздействие плюоксия на арахнидов, воздействие непрожаренных животных протеинов на арахнидов
