### PR TITLE
Реализация предложки

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -111,6 +111,14 @@
     sprite: Clothing/Belt/holster.rsi
   - type: Clothing
     sprite: Clothing/Belt/holster.rsi
+# Stories - start
+    slots: [belt, neck]
+    clothingVisuals:
+      neck:
+      - state: equipped-BELT
+      belt:
+      - state: equipped-BELT
+# Stories - end
   - type: Storage
     grid:
     - 0,0,3,1
@@ -125,6 +133,14 @@
     sprite: Clothing/Belt/syndieholster.rsi
   - type: Clothing
     sprite: Clothing/Belt/syndieholster.rsi
+# Stories - start
+    slots: [belt, neck]
+    clothingVisuals:
+      neck:
+      - state: equipped-BELT
+      belt:
+      - state: equipped-BELT
+# Stories - end
   - type: Storage
     maxItemSize: Huge
     grid:


### PR DESCRIPTION
## О PR
Данный ПР добавляет возможность носить плечевую кабуру в слоте neck - "на плечах"

## Почему / Баланс
Реализация предложки https://discord.com/channels/1111698541841240164/1509509607113097246

## Технические детали
в entity с id: ClothingBeltHolster в компонент Clothing было добавлено:
    slots: [belt, neck]
    clothingVisuals:
      neck:
      - state: equipped-BELT
      belt:
      - state: equipped-BELT
(Stories - start и end в комментариях указаны)

Все те же изменения касаются и entity с id: ClothingBeltSyndieHolster так как он почему-то не наследуется от ClothingBeltHolster

## Медиа
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре
<img width="182" height="237" alt="Screenshot_390" src="https://github.com/user-attachments/assets/eb45f275-5cd8-48bd-bb72-50c6070f6cea" />

**Changelog**
@JustGiveMeALaserSword
- tweak: Добавлена возможность носить простую и синдикатскую плечевую кобуру в слоте шеи - "на плечах"
