### PR TITLE
Исправление бага

### DIFF
--- a/Content.Server/_Stories/Economy/AtmSystem.cs
+++ b/Content.Server/_Stories/Economy/AtmSystem.cs
@@ -2,6 +2,7 @@ using Content.Server._Stories.Economy.Components;
 using Content.Server.Stack;
 using Content.Server.Station.Systems;
 using Content.Shared._Stories.Economy;
+using Content.Shared.Cargo.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Stacks;
 using Content.Shared.UserInterface;
@@ -96,7 +97,7 @@ public sealed partial class AtmSystem : EntitySystem
             return;
 
         if (TryComp<StackComponent>(args.Used, out var stack) &&
-            Prototype(args.Used)?.ID == "SpaceCash")
+            HasComp<CashComponent>(args.Used))
         {
             var station = _station.GetOwningStation(uid);
             if (station == null)


### PR DESCRIPTION
## О PR
Данный ПР исправляет баг из-за которого нельзя было вставлять кредиты в банкоматы, предварительно не разделив их

## Почему / Баланс
Это явно баг и не должно было так работать

## Технические детали
Ранее AtmSystem в Content.Server при попытке положить кредиты на счет проверял является ли айди сущности равным SpaceCash, что вызывало проблемы так как айди стаков кредитов (в которых большей 1 штуки) отличаются от вышеуказанного, из-за чего приходилось разделять стопку перед тем как положить кредиты на счёт. Теперь AtmSystem  проверяет наличие у сущности CashComponent, который имеют только все виды стаков кредитов, что полностью исправляет данную недоработку

## План тестирования
1. Убедиться что у сущности есть банковский счет, в случае отсутствия добавить его
2. Заспавнить банкомат и все виды стаков кредитов
3. Войти в счет в банкомате, попробовать положить кредиты с отличным от SpaceCash айди на счёт

## Media
Null

## Требования
- [X] Я ознакомился с [Руководством по созданию пул-реквестов и ведению журнала изменений](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) и следую его рекомендациям.
- [X] Я протестировал этот пул-реквест и написал(а) инструкции по его тестированию.
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре.

## Changelog
@JustGiveMeALaserSword
- fix: Теперь кредиты можно класть на счёт не разделяя их
