### PR TITLE
Звуки рас

### DIFF
--- a/Resources/Prototypes/Species/skeleton.yml
+++ b/Resources/Prototypes/Species/skeleton.yml
@@ -8,3 +8,5 @@
   femaleFirstNames: NamesSkeletonFirst
   dollPrototype: AppearanceSkeletonPerson
   skinColoration: TintedHues
+  defaultSoundsBySex:
+  - Skeleton

--- a/Resources/Prototypes/_Stories/Body/Species/kidan.yml
+++ b/Resources/Prototypes/_Stories/Body/Species/kidan.yml
@@ -107,7 +107,7 @@
     - Chitine
   - type: KidanAccent
   - type: Vocal
-    emoteSounds: UnsexedKidan
+    emoteSounds: MaleKidan
   - type: Damageable
     damageModifierSet: Kidan
   - type: Bioluminescence

--- a/Resources/Prototypes/_Stories/Species/avali.yml
+++ b/Resources/Prototypes/_Stories/Species/avali.yml
@@ -8,3 +8,10 @@
   maleFirstNames: AvaliUnisex
   femaleFirstNames: AvaliUnisex
   naming: First
+  defaultSoundsBySex:
+  - MaleAvali
+  - FemaleAvali
+  - MaleAvali
+  voices:
+  - MaleAvali
+  - FemaleAvali

--- a/Resources/Prototypes/_Stories/Species/felinid.yml
+++ b/Resources/Prototypes/_Stories/Species/felinid.yml
@@ -5,3 +5,10 @@
   prototype: MobFelinid
   dollPrototype: AppearanceFelinid
   skinColoration: HumanToned
+  defaultSoundsBySex:
+  - MaleFelinid
+  - FemaleFelinid
+  - MaleFelinid
+  voices:
+  - MaleFelinid
+  - FemaleFelinid

--- a/Resources/Prototypes/_Stories/Species/kidan.yml
+++ b/Resources/Prototypes/_Stories/Species/kidan.yml
@@ -9,3 +9,10 @@
   maleFirstNames: KidanMale
   femaleFirstNames: KidanMale
   naming: FirstDashFirst
+  defaultSoundsBySex:
+  - MaleKidan
+  - FemaleKidan
+  - MaleKidan
+  voices:
+  - MaleKidan
+  - FemaleKidan

--- a/Resources/Prototypes/_Stories/Species/rodentia.yml
+++ b/Resources/Prototypes/_Stories/Species/rodentia.yml
@@ -9,3 +9,10 @@
   maleFirstNames: RodentiaMale
   femaleFirstNames: RodentiaFemale
   lastNames: RodentiaLast
+  defaultSoundsBySex:
+  - MaleRodentia
+  - FemaleRodentia
+  - MaleRodentia
+  voices:
+  - MaleRodentia
+  - FemaleRodentia

--- a/Resources/Prototypes/_Stories/Voice/Avali/avali_emote_sounds.yml
+++ b/Resources/Prototypes/_Stories/Voice/Avali/avali_emote_sounds.yml
@@ -1,5 +1,6 @@
 - type: emoteSounds
   id: MaleAvali
+  voiceSelectorName: humanoid-profile-editor-voice-masculine
   params:
     variation: 0.125
   sounds:
@@ -42,6 +43,7 @@
 
 - type: emoteSounds
   id: FemaleAvali
+  voiceSelectorName: humanoid-profile-editor-voice-feminine
   params:
     variation: 0.125
   sounds:

--- a/Resources/Prototypes/_Stories/Voice/Felinid/felinid_emote_sounds.yml
+++ b/Resources/Prototypes/_Stories/Voice/Felinid/felinid_emote_sounds.yml
@@ -1,5 +1,6 @@
 - type: emoteSounds
   id: MaleFelinid
+  voiceSelectorName: humanoid-profile-editor-voice-masculine
   params:
     variation: 0.125
   sounds:
@@ -52,6 +53,7 @@
 
 - type: emoteSounds
   id: FemaleFelinid
+  voiceSelectorName: humanoid-profile-editor-voice-feminine
   params:
     variation: 0.125
   sounds:

--- a/Resources/Prototypes/_Stories/Voice/Rodentia/rodentia_emote_sounds.yml
+++ b/Resources/Prototypes/_Stories/Voice/Rodentia/rodentia_emote_sounds.yml
@@ -1,5 +1,6 @@
 - type: emoteSounds
   id: MaleRodentia
+  voiceSelectorName: humanoid-profile-editor-voice-masculine
   params:
     variation: 0.125
   sounds:
@@ -44,6 +45,7 @@
 
 - type: emoteSounds
   id: FemaleRodentia
+  voiceSelectorName: humanoid-profile-editor-voice-feminine
   params:
     variation: 0.125
   sounds:

--- a/Resources/Prototypes/_Stories/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Stories/Voice/speech_emote_sounds.yml
@@ -1,6 +1,7 @@
 # species
 - type: emoteSounds
-  id: UnsexedKidan
+  id: MaleKidan
+  voiceSelectorName: humanoid-profile-editor-voice-masculine
   params:
     variation: 0.125
   sounds:
@@ -47,6 +48,7 @@
 
 - type: emoteSounds
   id: FemaleKidan
+  voiceSelectorName: humanoid-profile-editor-voice-feminine
   params:
     variation: 0.125
   sounds:


### PR DESCRIPTION
## О PR
Ранее уникальные звуки эмоций сторисовских рас и скелета заменялись на человеческие, данный ПР исправляет данную недоработку

## Почему / Баланс
Это явно не должно было так работать. На исправление подтолкнул репорт о данном баге в ДСе https://discord.com/channels/1111698541841240164/1529560676442308918

## Технические детали
Изменения касаются сугубо yml файлов

## План тестирования
Требуется последовательно создать персонажа каждой сторисовской расы (кидан, авали, родентия, фелинид) в главном меню каждого из доступных полов и удостовериться в том что как минимум уникальные звуки крика для каждой расы каждого пола работают. Добавить игровое правило ClosetSkeleton, зайти за него через роли призраков и удостовериться в том что уникальные звуки крива скелета работают для обоих полов расы (возможно придется добавить правило больше двух раз)

## Media
Null

## Требования
- [X] Я ознакомился с [Руководством по созданию пул-реквестов и ведению журнала изменений](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) и следую его рекомендациям.
- [X] Я протестировал этот пул-реквест и написал(а) инструкции по его тестированию.
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре.

## Changelog
:cl: @JustGiveMeALaserSword4 
- fix: Исправлены звуки эмоций сторисовских рас и скелета
