### PR TITLE
Торговые автоматы

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -2318,6 +2318,9 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+    freeJobs:
+    - ChiefMedicalOfficer
+    - Chemist
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chemvend.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1411,6 +1411,11 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+    freeJobs:
+    - StationEngineer
+    - ChiefEngineer
+    - AtmosphericTechnician
+    - TechnicalAssistant
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/youtool.rsi
     layers:
@@ -1505,6 +1510,7 @@
     denyState: deny-unshaded
     freeJobs:
     - SalvageSpecialist
+    - Quartermaster
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/mining.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1510,7 +1510,6 @@
     denyState: deny-unshaded
     freeJobs:
     - SalvageSpecialist
-    - Quartermaster
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/mining.rsi
     layers:


### PR DESCRIPTION
## О PR
Данный ПР позволяет всем членам инженерного отдела бесплатно пользоваться автоматом "твоИнструменты", КМу бесплатно пользоваться автоматом "утильмаг", а ГВ и химикам бесплатно пользоваться автоматом "химкоМат"

## Почему / Баланс
Странно что инженерам приходится платить за стандартную экипировку их отдела, не менее странно что главе отдела снабжения приходится платить за экипировку утилизаторов
Необходимость платить за различные химикаты главному врачу и химикам сильно замедляла работу медицинского отдела и часто это ограничение обходилось

## Технические детали
Изменения касаются сугубо yml файлов

## План тестирования
Необходимо проверить могут ли все члены инженерного отдела бесплатно покупать экипировку из автомата "твоИнструменты", проверить может ли квартирмейстер бесплатно покупать экипировку из автомата "утильмаг" и проверить могут ли главный врач и химики бесплатно покупать экипировку из автомата "химкоМат"

## Media
Null

## Требования
- [X] Я ознакомился с [Руководством по созданию пул-реквестов и ведению журнала изменений](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) и следую его рекомендациям.
- [X] Я протестировал этот пул-реквест и написал(а) инструкции по его тестированию.
- [X] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре.

## Changelog
:cl: @JustGiveMeALaserSword4 
- tweak: Теперь инженеры могут бесплатно пользоваться автоматом "твоИнструменты"
- tweak: Теперь КМ может бесплатно пользоваться автоматом "утильмаг"
- tweak: Теперь химики и ГВ могут бесплатно пользоваться автоматом "химкоМат"