### PR TITLE
Ахелпы[update]

### DIFF
--- a/Content.Client/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Client/Administration/Systems/BwoinkSystem.cs
@@ -12,12 +12,34 @@ namespace Content.Client.Administration.Systems
         [Dependency] private IGameTiming _timing = default!;
 
         public event EventHandler<BwoinkTextMessage>? OnBwoinkTextMessageRecieved;
+        public event EventHandler<BwoinkHistoryMessage>? OnBwoinkHistoryReceived; // Stories-FixAchat
         private (TimeSpan Timestamp, bool Typing) _lastTypingUpdateSent;
+
+        // Stories-FixAchat-Start
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeNetworkEvent<BwoinkHistoryMessage>(OnHistoryMessage);
+        }
+        // Stories-FixAchat-End
 
         protected override void OnBwoinkTextMessage(BwoinkTextMessage message, EntitySessionEventArgs eventArgs)
         {
             OnBwoinkTextMessageRecieved?.Invoke(this, message);
         }
+
+        // Stories-FixAchat-Start
+        private void OnHistoryMessage(BwoinkHistoryMessage message, EntitySessionEventArgs args)
+        {
+            OnBwoinkHistoryReceived?.Invoke(this, message);
+        }
+
+        public void RequestHistory(NetUserId channel)
+        {
+            RaiseNetworkEvent(new BwoinkRequestHistoryMessage(channel));
+        }
+        // Stories-FixAchat-End
 
         public void Send(NetUserId channelId, string text, bool playSound, bool adminOnly)
         {

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -287,6 +287,7 @@ namespace Content.Client.Administration.UI.Bwoink
             {
                 var panel = AHelpHelper.EnsurePanel(ch.Value);
                 panel.Visible = true;
+                AHelpHelper.RequestHistoryIfNeeded(ch.Value); // Stories-FixAchat
             }
         }
 

--- a/Content.Client/Administration/UI/Bwoink/BwoinkPanel.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkPanel.xaml.cs
@@ -70,11 +70,27 @@ namespace Content.Client.Administration.UI.Bwoink
             if (!Visible)
                 Unread++;
 
+            AppendLine(message);
+        }
+
+        // Stories-FixAchat-Start
+        public void ReceiveHistory(IEnumerable<SharedBwoinkSystem.BwoinkTextMessage> messages)
+        {
+            foreach (var message in messages)
+            {
+                AppendLine(message);
+            }
+        }
+
+        private void AppendLine(SharedBwoinkSystem.BwoinkTextMessage message)
+        {
             var formatted = new FormattedMessage(1);
             formatted.AddMarkupOrThrow($"[color=gray]{message.SentAt.ToShortTimeString()}[/color] {message.Text}");
             TextOutput.AddMessage(formatted, AllowedTags);
-            LastMessage = message.SentAt;
+            if (message.SentAt > LastMessage)
+                LastMessage = message.SentAt;
         }
+        // Stories-FixAchat-End
 
         private void UpdateTypingIndicator()
         {

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -411,6 +411,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     public void ToggleWindow()
     {
         EnsurePanel(_ownerId);
+        RequestHistoryIfNeeded(_ownerId); // Stories-FixAchat
 
         if (IsOpen)
             Close();
@@ -491,11 +492,19 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         if (!Control!.BwoinkArea.Children.Contains(existingPanel))
             Control.BwoinkArea.AddChild(existingPanel);
 
-        RequestHistoryAction?.Invoke(channelId); // Stories-FixAchat
-
         return existingPanel;
     }
     public bool TryGetChannel(NetUserId ch, [NotNullWhen(true)] out BwoinkPanel? bp) => _activePanelMap.TryGetValue(ch, out bp);
+
+    // Stories-FixAchat-Start
+    private readonly HashSet<NetUserId> _historyRequested = new();
+
+    public void RequestHistoryIfNeeded(NetUserId channelId)
+    {
+        if (_historyRequested.Add(channelId))
+            RequestHistoryAction?.Invoke(channelId);
+    }
+    // Stories-FixAchat-End
 
     private void SelectChannel(NetUserId uid)
     {
@@ -509,6 +518,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         Window = null;
         Control = null;
         _activePanelMap.Clear();
+        _historyRequested.Clear(); // Stories-FixAchat
         EverOpened = false;
     }
 }
@@ -615,8 +625,6 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
         var introText = Loc.GetString("bwoink-system-introductory-message");
         var introMessage = new SharedBwoinkSystem.BwoinkTextMessage( _ownerId, SharedBwoinkSystem.SystemUserId, introText);
         Receive(introMessage);
-
-        RequestHistoryAction?.Invoke(_ownerId); // Stories-FixAchat
     }
 
     public void Dispose()

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -99,6 +99,7 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
     {
         _bwoinkSystem = system;
         _bwoinkSystem.OnBwoinkTextMessageRecieved += ReceivedBwoink;
+        _bwoinkSystem.OnBwoinkHistoryReceived += ReceivedHistory; // Stories-FixAchat
 
         _input.SetInputCommand(ContentKeyFunctions.OpenAHelp,
             InputCmdHandler.FromDelegate(_ => ToggleWindow()));
@@ -110,6 +111,7 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
 
         DebugTools.Assert(_bwoinkSystem != null);
         _bwoinkSystem!.OnBwoinkTextMessageRecieved -= ReceivedBwoink;
+        _bwoinkSystem.OnBwoinkHistoryReceived -= ReceivedHistory; // Stories-FixAchat
         _bwoinkSystem = null;
     }
 
@@ -154,6 +156,13 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
         UIHelper!.Receive(message);
     }
 
+    // Stories-FixAchat-Start
+    private void ReceivedHistory(object? sender, BwoinkHistoryMessage message)
+    {
+        UIHelper?.ReceiveHistory(message.Channel, message.Messages);
+    }
+    // Stories-FixAchat-End
+
     private void DiscordRelayUpdated(BwoinkDiscordRelayUpdated args, EntitySessionEventArgs session)
     {
         _discordRelayActive = args.DiscordRelayEnabled;
@@ -178,6 +187,7 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
         UIHelper.DiscordRelayChanged(_discordRelayActive);
 
         UIHelper.SendMessageAction = (userId, textMessage, playSound, adminOnly) => _bwoinkSystem?.Send(userId, textMessage, playSound, adminOnly);
+        UIHelper.RequestHistoryAction = channel => _bwoinkSystem?.RequestHistory(channel); // Stories-FixAchat
         UIHelper.InputTextChanged += (channel, text) => _bwoinkSystem?.SendInputTextUpdated(channel, text.Length > 0);
         UIHelper.OnClose += () => { SetAHelpPressed(false); };
         UIHelper.OnOpen +=  () => { SetAHelpPressed(true); };
@@ -319,6 +329,7 @@ public interface IAHelpUIHandler : IDisposable
     public bool IsAdmin { get; }
     public bool IsOpen { get; }
     public void Receive(SharedBwoinkSystem.BwoinkTextMessage message);
+    public void ReceiveHistory(NetUserId channel, List<SharedBwoinkSystem.BwoinkTextMessage> messages); // Stories-FixAchat
     public void Close();
     public void Open(NetUserId netUserId, bool relayActive);
     public void ToggleWindow();
@@ -327,6 +338,7 @@ public interface IAHelpUIHandler : IDisposable
     public event Action OnClose;
     public event Action OnOpen;
     public Action<NetUserId, string, bool, bool>? SendMessageAction { get; set; }
+    public Action<NetUserId>? RequestHistoryAction { get; set; } // Stories-FixAchat
     public event Action<NetUserId, string>? InputTextChanged;
 }
 public sealed class AdminAHelpUIHandler : IAHelpUIHandler
@@ -352,6 +364,14 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         panel.ReceiveLine(message);
         Control?.OnBwoink(message.UserId);
     }
+
+    // Stories-FixAchat-Start
+    public void ReceiveHistory(NetUserId channel, List<SharedBwoinkSystem.BwoinkTextMessage> messages)
+    {
+        if (_activePanelMap.TryGetValue(channel, out var panel))
+            panel.ReceiveHistory(messages);
+    }
+    // Stories-FixAchat-End
 
     private void OpenWindow()
     {
@@ -411,6 +431,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     public event Action? OnClose;
     public event Action? OnOpen;
     public Action<NetUserId, string, bool, bool>? SendMessageAction { get; set; }
+    public Action<NetUserId>? RequestHistoryAction { get; set; } // Stories-FixAchat
     public event Action<NetUserId, string>? InputTextChanged;
 
     public void Open(NetUserId channelId, bool relayActive)
@@ -470,6 +491,8 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         if (!Control!.BwoinkArea.Children.Contains(existingPanel))
             Control.BwoinkArea.AddChild(existingPanel);
 
+        RequestHistoryAction?.Invoke(channelId); // Stories-FixAchat
+
         return existingPanel;
     }
     public bool TryGetChannel(NetUserId ch, [NotNullWhen(true)] out BwoinkPanel? bp) => _activePanelMap.TryGetValue(ch, out bp);
@@ -511,6 +534,17 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
         _window!.OpenCentered();
     }
 
+    // Stories-FixAchat-Start
+    public void ReceiveHistory(NetUserId channel, List<SharedBwoinkSystem.BwoinkTextMessage> messages)
+    {
+        if (channel != _ownerId)
+            return;
+
+        EnsureInit(_discordRelayActive);
+        _chatPanel!.ReceiveHistory(messages);
+    }
+    // Stories-FixAchat-End
+
     public void Close()
     {
         _window?.Close();
@@ -551,6 +585,7 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
     public event Action? OnClose;
     public event Action? OnOpen;
     public Action<NetUserId, string, bool, bool>? SendMessageAction { get; set; }
+    public Action<NetUserId>? RequestHistoryAction { get; set; } // Stories-FixAchat
     public event Action<NetUserId, string>? InputTextChanged;
 
     public void Open(NetUserId channelId, bool relayActive)
@@ -580,6 +615,8 @@ public sealed class UserAHelpUIHandler : IAHelpUIHandler
         var introText = Loc.GetString("bwoink-system-introductory-message");
         var introMessage = new SharedBwoinkSystem.BwoinkTextMessage( _ownerId, SharedBwoinkSystem.SystemUserId, introText);
         Receive(introMessage);
+
+        RequestHistoryAction?.Invoke(_ownerId); // Stories-FixAchat
     }
 
     public void Dispose()

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -149,14 +149,14 @@ namespace Content.Server.Administration.Systems
             SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameRunLevelChanged);
             SubscribeNetworkEvent<BwoinkClientTypingUpdated>(OnClientTypingUpdated);
             SubscribeNetworkEvent<BwoinkRequestHistoryMessage>(OnHistoryRequested); // Stories-FixAchat
-            SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => _activeConversations.Clear());
-            // Stories-FixAchat-Start
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ =>
             {
+                _activeConversations.Clear();
+                // Stories-FixAchat-Start
                 _historyForAdmins.Clear();
                 _historyForPlayer.Clear();
+                // Stories-FixAchat-End
             });
-            // Stories-FixAchat-End
 
             _rateLimit.Register(
                 RateLimitKey,

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -35,6 +35,7 @@ namespace Content.Server.Administration.Systems
     public sealed partial class BwoinkSystem : SharedBwoinkSystem
     {
         private const string RateLimitKey = "AdminHelp";
+        private const string HistoryRateLimitKey = "AdminHelpHistory"; // Stories-FixAchat
 
         [Dependency] private IPlayerManager _playerManager = default!;
         [Dependency] private IAdminManager _adminManager = default!;
@@ -105,24 +106,18 @@ namespace Content.Server.Administration.Systems
         private void OnHistoryRequested(BwoinkRequestHistoryMessage msg, EntitySessionEventArgs args)
         {
             var sender = args.SenderSession;
+
+            if (_rateLimit.CountAction(sender, HistoryRateLimitKey) != RateLimitStatus.Allowed) // Stories-FixAchat
+                return;
+
             var isAdmin = _adminManager.GetAdminData(sender)?.HasFlag(AdminFlags.Adminhelp) ?? false;
-
-            if (isAdmin)
-            {
-                var adminHistory = _historyForAdmins.TryGetValue(msg.Channel, out var adminList)
-                    ? adminList
-                    : new List<BwoinkTextMessage>();
-                RaiseNetworkEvent(new BwoinkHistoryMessage(msg.Channel, adminHistory), sender);
-                return;
-            }
-
-            if (sender.UserId != msg.Channel)
+            if (!isAdmin)
                 return;
 
-            var playerHistory = _historyForPlayer.TryGetValue(msg.Channel, out var playerList)
-                ? playerList
+            var adminHistory = _historyForAdmins.TryGetValue(msg.Channel, out var adminList)
+                ? new List<BwoinkTextMessage>(adminList)
                 : new List<BwoinkTextMessage>();
-            RaiseNetworkEvent(new BwoinkHistoryMessage(msg.Channel, playerHistory), sender);
+            RaiseNetworkEvent(new BwoinkHistoryMessage(msg.Channel, adminHistory), sender);
         }
         // Stories-FixAchat-End
 
@@ -155,6 +150,13 @@ namespace Content.Server.Administration.Systems
             SubscribeNetworkEvent<BwoinkClientTypingUpdated>(OnClientTypingUpdated);
             SubscribeNetworkEvent<BwoinkRequestHistoryMessage>(OnHistoryRequested); // Stories-FixAchat
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => _activeConversations.Clear());
+            // Stories-FixAchat-Start
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(_ =>
+            {
+                _historyForAdmins.Clear();
+                _historyForPlayer.Clear();
+            });
+            // Stories-FixAchat-End
 
             _rateLimit.Register(
                 RateLimitKey,
@@ -162,6 +164,15 @@ namespace Content.Server.Administration.Systems
                     CCVars.AhelpRateLimitCount,
                     PlayerRateLimitedAction)
                 );
+
+            // Stories-FixAchat-Start
+            _rateLimit.Register(
+                HistoryRateLimitKey,
+                new RateLimitRegistration(CCVars.AhelpHistoryRateLimitPeriod,
+                    CCVars.AhelpHistoryRateLimitCount,
+                    null)
+                );
+            // Stories-FixAchat-End
         }
 
         private async void OnCallChanged(string url)
@@ -248,6 +259,13 @@ namespace Content.Server.Administration.Systems
                 return;
 
             RaiseNetworkEvent(new BwoinkDiscordRelayUpdated(!string.IsNullOrWhiteSpace(_webhookUrl)), e.Session);
+
+            // Stories-FixAchat-Start
+            if (_historyForPlayer.TryGetValue(e.Session.UserId, out var ownHistory) && ownHistory.Count > 0)
+            {
+                RaiseNetworkEvent(new BwoinkHistoryMessage(e.Session.UserId, new List<BwoinkTextMessage>(ownHistory)), e.Session);
+            }
+            // Stories-FixAchat-End
         }
 
         private void NotifyAdmins(ICommonSession session, string message, PlayerStatusType statusType)

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -89,6 +89,43 @@ namespace Content.Server.Administration.Systems
         private int _maxAdditionalChars;
         private readonly Dictionary<NetUserId, DateTime> _activeConversations = new();
 
+        // Stories-FixAchat-Start
+        private const int MaxHistoryPerChannel = 100;
+        private readonly Dictionary<NetUserId, List<BwoinkTextMessage>> _historyForAdmins = new();
+        private readonly Dictionary<NetUserId, List<BwoinkTextMessage>> _historyForPlayer = new();
+
+        private static void AddHistory(Dictionary<NetUserId, List<BwoinkTextMessage>> history, NetUserId channel, BwoinkTextMessage message)
+        {
+            var list = history.GetOrNew(channel);
+            list.Add(message);
+            if (list.Count > MaxHistoryPerChannel)
+                list.RemoveAt(0);
+        }
+
+        private void OnHistoryRequested(BwoinkRequestHistoryMessage msg, EntitySessionEventArgs args)
+        {
+            var sender = args.SenderSession;
+            var isAdmin = _adminManager.GetAdminData(sender)?.HasFlag(AdminFlags.Adminhelp) ?? false;
+
+            if (isAdmin)
+            {
+                var adminHistory = _historyForAdmins.TryGetValue(msg.Channel, out var adminList)
+                    ? adminList
+                    : new List<BwoinkTextMessage>();
+                RaiseNetworkEvent(new BwoinkHistoryMessage(msg.Channel, adminHistory), sender);
+                return;
+            }
+
+            if (sender.UserId != msg.Channel)
+                return;
+
+            var playerHistory = _historyForPlayer.TryGetValue(msg.Channel, out var playerList)
+                ? playerList
+                : new List<BwoinkTextMessage>();
+            RaiseNetworkEvent(new BwoinkHistoryMessage(msg.Channel, playerHistory), sender);
+        }
+        // Stories-FixAchat-End
+
         public override void Initialize()
         {
             base.Initialize();
@@ -116,6 +153,7 @@ namespace Content.Server.Administration.Systems
 
             SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameRunLevelChanged);
             SubscribeNetworkEvent<BwoinkClientTypingUpdated>(OnClientTypingUpdated);
+            SubscribeNetworkEvent<BwoinkRequestHistoryMessage>(OnHistoryRequested); // Stories-FixAchat
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => _activeConversations.Clear());
 
             _rateLimit.Register(
@@ -155,9 +193,9 @@ namespace Content.Server.Administration.Systems
 
         private void PlayerRateLimitedAction(ICommonSession obj)
         {
-            RaiseNetworkEvent(
-                new BwoinkTextMessage(obj.UserId, default, Loc.GetString("bwoink-system-rate-limited"), playSound: false),
-                obj.Channel);
+            var msg = new BwoinkTextMessage(obj.UserId, default, Loc.GetString("bwoink-system-rate-limited"), playSound: false);
+            AddHistory(_historyForPlayer, obj.UserId, msg); // Stories-FixAchat
+            RaiseNetworkEvent(msg, obj.Channel);
         }
 
         private void OnOverrideChanged(string obj)
@@ -267,6 +305,8 @@ namespace Content.Server.Administration.Systems
             {
                 RaiseNetworkEvent(bwoinkMessage, admin);
             }
+
+            AddHistory(_historyForAdmins, session.UserId, bwoinkMessage); // Stories-FixAchat
 
             // Enqueue the message for Discord relay
             if (_webhookUrl != string.Empty)
@@ -777,6 +817,7 @@ namespace Content.Server.Administration.Systems
 
             var admins = GetTargetAdmins();
             var adminMsg = await FormatFullMessageForRecipient(forAdmin: true, senderAdmin, senderSession, message);
+            AddHistory(_historyForAdmins, message.UserId, adminMsg); // Stories-FixAchat
 
             // Notify all admins
             foreach (var channel in admins)
@@ -785,11 +826,14 @@ namespace Content.Server.Administration.Systems
             }
 
             // Notify player
-            if (_playerManager.TryGetSessionById(message.UserId, out var session) && !message.AdminOnly)
+            if (!message.AdminOnly)
             {
-                if (!admins.Contains(session.Channel))
+                var playerMsg = await FormatFullMessageForRecipient(forAdmin: false, senderAdmin, senderSession, message);
+                AddHistory(_historyForPlayer, message.UserId, playerMsg); // Stories-FixAchat
+
+                if (_playerManager.TryGetSessionById(message.UserId, out var session) &&
+                    !admins.Contains(session.Channel))
                 {
-                    var playerMsg = await FormatFullMessageForRecipient(forAdmin: false, senderAdmin, senderSession, message);
                     RaiseNetworkEvent(playerMsg, session.Channel);
                 }
             }
@@ -828,6 +872,7 @@ namespace Content.Server.Administration.Systems
             // No admin online, let the player know
             var systemText = Loc.GetString("bwoink-system-starmute-message-no-other-users");
             var starMuteMsg = new BwoinkTextMessage(message.UserId, SystemUserId, systemText);
+            AddHistory(_historyForPlayer, message.UserId, starMuteMsg); // Stories-FixAchat
             RaiseNetworkEvent(starMuteMsg, senderSession.Channel);
         }
 

--- a/Content.Shared/Administration/SharedBwoinkSystem.cs
+++ b/Content.Shared/Administration/SharedBwoinkSystem.cs
@@ -65,6 +65,32 @@ namespace Content.Shared.Administration
         }
     }
 
+    // Stories-FixAchat-Start
+    [Serializable, NetSerializable]
+    public sealed class BwoinkRequestHistoryMessage : EntityEventArgs
+    {
+        public NetUserId Channel { get; }
+
+        public BwoinkRequestHistoryMessage(NetUserId channel)
+        {
+            Channel = channel;
+        }
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class BwoinkHistoryMessage : EntityEventArgs
+    {
+        public NetUserId Channel { get; }
+        public List<SharedBwoinkSystem.BwoinkTextMessage> Messages { get; }
+
+        public BwoinkHistoryMessage(NetUserId channel, List<SharedBwoinkSystem.BwoinkTextMessage> messages)
+        {
+            Channel = channel;
+            Messages = messages;
+        }
+    }
+    // Stories-FixAchat-End
+
     /// <summary>
     ///     Sent by the client to notify the server when it begins or stops typing.
     /// </summary>

--- a/Content.Shared/CCVar/CCVars.Admin.Ahelp.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.Ahelp.cs
@@ -19,6 +19,14 @@ public sealed partial class CCVars
     public static readonly CVarDef<int> AhelpRateLimitCount =
         CVarDef.Create("ahelp.rate_limit_count", 10, CVar.SERVERONLY);
 
+    // Stories-FixAchat-Start
+    public static readonly CVarDef<float> AhelpHistoryRateLimitPeriod =
+        CVarDef.Create("ahelp.history_rate_limit_period", 2f, CVar.SERVERONLY);
+
+    public static readonly CVarDef<int> AhelpHistoryRateLimitCount =
+        CVarDef.Create("ahelp.history_rate_limit_count", 30, CVar.SERVERONLY);
+    // Stories-FixAchat-End
+
     /// <summary>
     ///     Should the administrator's position be displayed in ahelp.
     ///     If it is is false, only the admin's ckey will be displayed in the ahelp.


### PR DESCRIPTION

## О PR
<!-- Что вы изменили в этом PR? -->
Исправил момент, когда администратор мог вылететь/выйти и при перезаходе теряет историю сообщений у игрока. Для этого ему пришлось бы открыть дискорд и посмотреть что он/игрок писал. Теперь же сервер кэширует эти сообщения в памяти и когда игрок/администратор заходит -- клиент запрашивает у сервера историю. Игрок не может увидеть историю администратора или историю другого игрока, поскольку чат привязан к айди и его же запрашивает при переподключении для изображения истории. 

БД не потрогано и истории не сохраняются после перезагрузки сервера. Лимит уставновлен в 100 сообщений во избежания засорения мусором. 

## Требования
<!-- Подтвердите следующее, поставив букву «X» в скобках без пробелов внутри (например: [X] ): -->
- [x] Я ознакомился с [Руководством по созданию пул-реквестов и ведению журнала изменений](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) и следую его рекомендациям.
- [x] Я протестировал этот пул-реквест и написал(а) инструкции по его тестированию.
- [x] Я добавил к этому PR скриншоты/видео, демонстрирующие его изменения в игре, **или** этот PR не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанных требований может привести к закрытию вашего пул-реквеста по усмотрению рассматривающего -->

## Changelog
:cl:
- admin: Добавлено кеширование админ сообщений. Теперь при перезаходе у игрока/администратора сохраняются их сообщения в админ чате. Лимит 100 сообщений. 
